### PR TITLE
version bump 1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CachedContentful.Mixfile do
   def project do
     [
       app: :cached_contentful,
-      version: "0.5.0",
+      version: "1.0.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       deps: deps()


### PR DESCRIPTION
apparently going up to 1.0.0 is long overdue: https://github.com/weareyipyip/elixir-cached-contentful/pull/14#discussion_r340522866 